### PR TITLE
Remove test that prevented Socket.io to get initialized

### DIFF
--- a/client/app/initialize.coffee
+++ b/client/app/initialize.coffee
@@ -28,7 +28,6 @@ $ ->
 
         url = window.location.origin
         pathToSocketIO = "/#{window.location.pathname.substring(1)}socket.io"
-        console.log toto.titi
 
         window.sio = io url,
             path: pathToSocketIO


### PR DESCRIPTION
This fix a regression introduced by my previous commit ☹
I committed an error intentionally put in code to check that client error reporting was working. This error prevent the socket initialization, so the application is probably broken.
Sorry ☹
